### PR TITLE
feat : use API

### DIFF
--- a/MangoDiary/package-lock.json
+++ b/MangoDiary/package-lock.json
@@ -8,9 +8,10 @@
       "name": "mangodiary",
       "version": "0.0.0",
       "dependencies": {
+        "@fortawesome/fontawesome-free": "^6.5.1",
         "axios": "^1.6.7",
         "vue": "^3.3.11",
-        "vue-router": "^4.0.13",
+        "vue-router": "^4.3.0",
         "vuex": "^4.1.0"
       },
       "devDependencies": {
@@ -406,6 +407,15 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.1.tgz",
       "integrity": "sha512-GkWzv+L6d2bI5f/Vk6ikJ9xtl7dfXtoRu3YGE6nq0p/FFqA1ebMOAWg3XgRyb0I6LYyYkiAo+3/KrwuBp8xG7A==",
       "dev": true,
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.1.tgz",
+      "integrity": "sha512-CNy5vSwN3fsUStPRLX7fUYojyuzoEMSXPl7zSLJ8TgtRfjv24LOnOWKT2zYwaHZCJGkdyRnTmstR0P+Ah503Gw==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=6"
@@ -1087,11 +1097,11 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.13.tgz",
-      "integrity": "sha512-LmXrC+BkDRLak+d5xTMgUYraT3Nj0H/vCbP+7usGvIl9Viqd1UP6AsP0i69pSbn9O0dXK/xCdp4yPw21HqV9Jw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.3.0.tgz",
+      "integrity": "sha512-dqUcs8tUeG+ssgWhcPbjHvazML16Oga5w34uCUmsk7i0BcnskoLGwjpa15fqMr2Fa5JgVBrdL2MEgqz6XZ/6IQ==",
       "dependencies": {
-        "@vue/devtools-api": "^6.0.0"
+        "@vue/devtools-api": "^6.5.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/posva"

--- a/MangoDiary/package-lock.json
+++ b/MangoDiary/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mangodiary",
       "version": "0.0.0",
       "dependencies": {
+        "axios": "^1.6.7",
         "vue": "^3.3.11",
         "vue-router": "^4.0.13",
         "vuex": "^4.1.0"
@@ -747,10 +748,44 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.6.tgz",
       "integrity": "sha512-O16vewA05D0IwfG2N/OFEuVeb17pieaI32mmYXp36V8lp+/pI1YV04rRL9Eyjndj3xQO5SNjAxTh6ul4IlBa3A=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -806,6 +841,38 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -829,6 +896,25 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/nanoid": {
@@ -879,6 +965,11 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/rollup": {
       "version": "4.9.4",

--- a/MangoDiary/package.json
+++ b/MangoDiary/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host 0.0.0.0",
     "build": "vite build",
     "preview": "vite preview"
   },

--- a/MangoDiary/package.json
+++ b/MangoDiary/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.6.7",
     "vue": "^3.3.11",
     "vue-router": "^4.0.13",
     "vuex": "^4.1.0"

--- a/MangoDiary/package.json
+++ b/MangoDiary/package.json
@@ -9,9 +9,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-free": "^6.5.1",
     "axios": "^1.6.7",
     "vue": "^3.3.11",
-    "vue-router": "^4.0.13",
+    "vue-router": "^4.3.0",
     "vuex": "^4.1.0"
   },
   "devDependencies": {

--- a/MangoDiary/src/components/CalendarPage.vue
+++ b/MangoDiary/src/components/CalendarPage.vue
@@ -83,13 +83,8 @@ export default {
       this.calendar = this.generateCalendar()
     },
     getDiaryId(day) {
-      const matchingDiaryEntries = this.$store.state.diary.filter(
-        (entry) =>
-          parseInt(entry.post_year) == this.$store.state.selectedYear &&
-          parseInt(entry.post_month) == this.$store.state.selectedMonth &&
-          parseInt(entry.post_date) == day
-      );
-      return matchingDiaryEntries.length > 0 ? matchingDiaryEntries[0]?.post_id : -1
+      const matchingDiaryEntries = this.$store.state.posts.filter((entry) => parseInt(entry.post_date) == day)
+      return matchingDiaryEntries.length > 0 ? matchingDiaryEntries[matchingDiaryEntries.length - 1]?.post_id : -1
     },
     getSelectedEmojiPath(day) {
       const result = this.$store.state.posts.filter((post) => parseInt(post.post_date) == day)

--- a/MangoDiary/src/components/CalendarPage.vue
+++ b/MangoDiary/src/components/CalendarPage.vue
@@ -45,7 +45,6 @@
 </template>
 
 <script>
-import axios from 'axios'
 export default {
   data() {
     return {

--- a/MangoDiary/src/components/CalendarPage.vue
+++ b/MangoDiary/src/components/CalendarPage.vue
@@ -144,6 +144,7 @@ export default {
   },
   async mounted() {
     this.$store.commit('getToday')
+    await this.$store.dispatch('getAllEmojis')
     await this.$store.dispatch('getAllPosts')
     this.updateCalendar()
   },

--- a/MangoDiary/src/components/CalendarPage.vue
+++ b/MangoDiary/src/components/CalendarPage.vue
@@ -45,6 +45,7 @@
 </template>
 
 <script>
+import axios from 'axios'
 export default {
   data() {
     return {

--- a/MangoDiary/src/components/CalendarPage.vue
+++ b/MangoDiary/src/components/CalendarPage.vue
@@ -92,8 +92,8 @@ export default {
       return matchingDiaryEntries.length > 0 ? matchingDiaryEntries[0]?.post_id : -1
     },
     getSelectedEmojiPath(day) {
-      const diaryId = this.getDiaryId(day)
-      return diaryId == -1 ? '' : `images/colored/${this.$store.state.diary[diaryId].post_emoji}.jpg`
+      const result = this.$store.state.posts.filter((post) => parseInt(post.post_date) == day)
+      return result.length > 0 ? result[result.length - 1]?.post_emoji_url : ""
     },
     updateCalendar() {
       this.calendar = this.generateCalendar()

--- a/MangoDiary/src/components/CalendarPage.vue
+++ b/MangoDiary/src/components/CalendarPage.vue
@@ -59,12 +59,12 @@ export default {
   },
   methods: {
     generateCalendar() {
-      const firstDay = new Date(this.$store.state.selectedYear, this.$store.state.selectedMonth - 1, 1).getDay();
-      const daysInMonth = new Date(this.$store.state.selectedYear, this.$store.state.selectedMonth, 0).getDate();
-      const row = 7;
-      let col = 5;
-      const calendar = [];
-      let dayCount = 1;
+      const firstDay = new Date(this.$store.state.selectedYear, this.$store.state.selectedMonth - 1, 1).getDay()
+      const daysInMonth = new Date(this.$store.state.selectedYear, this.$store.state.selectedMonth, 0).getDate()
+      const row = 7
+      let col = 5
+      const calendar = []
+      let dayCount = 1
       if ((firstDay + daysInMonth) > 35) col = 6
       for (let i = 0; i < col; i++) {
         const week = []

--- a/MangoDiary/src/components/CalendarPage.vue
+++ b/MangoDiary/src/components/CalendarPage.vue
@@ -126,7 +126,7 @@ export default {
     showDay(day) {
       return day ?? "ㅤ"
     },
-    handleClickChangeMonth(monthSet) {
+    async handleClickChangeMonth(monthSet) {
       const selectMonth = this.$store.state.selectedMonth + monthSet
       this.$store.commit('setSelectedMonth', selectMonth)
       if ((selectMonth) < 1) {
@@ -135,14 +135,16 @@ export default {
         this.$store.commit('increaseSelectedYear')
       }
       this.updateCalendar()
+      await this.$store.dispatch('getAllPosts')
     },
     changePointer(day) {
       if(this.isFutureDate(day)) return
       return day == null ? "" : "pointer-cursor"
     }
   },
-  mounted() {
+  async mounted() {
     this.$store.commit('getToday')
+    await this.$store.dispatch('getAllPosts')
     this.updateCalendar()
   },
 };

--- a/MangoDiary/src/components/StatisticsPage.vue
+++ b/MangoDiary/src/components/StatisticsPage.vue
@@ -84,6 +84,7 @@ export default {
   },
   async mounted() {
     this.$store.commit('getToday')
+    await this.$store.dispatch('getAllEmojis')
     await this.$store.dispatch('getAllPosts')
     this.$store.commit('updateStatistic')
   },

--- a/MangoDiary/src/components/StatisticsPage.vue
+++ b/MangoDiary/src/components/StatisticsPage.vue
@@ -18,7 +18,7 @@
     </header>
     <div>
       <div class="most-selected-container" v-if="this.$store.state.statisticsData[0]?.count ?? 0 > 0">
-        <img :src="getMostSelectedEmojiPath()" class="most-selected-emoji">
+        <img :src="getEmojiPath(this.$store.state.statisticsData[0])" class="most-selected-emoji">
         <div class="left-align-content">
           <h4 class="selected-month">{{ this.$store.state.statisticsData[0]?.month ?? "" }}</h4>
           <p class="detail">{{ this.$store.state.statisticsData[0]?.name ?? "" }} 망고 {{ this.$store.state.statisticsData[0]?.count ?? 0 }}개</p>
@@ -64,11 +64,14 @@ export default {
       this.$router.push(this.$store.state.calendar)
     },
     getEmojiPath(data) {
-      if (data.count > 0) return `/images/colored/${data.emoji}.jpg`
-      return `/images/grey/${data.emoji}.jpg`
-    },
-    getMostSelectedEmojiPath() {
-      return `/images/colored/${this.$store.state.statisticsData[0].emoji}.jpg`
+      let emojiName = ''
+      this.$store.state.emojis.forEach(emoji => {
+        if(emoji.emoji_id == data.emoji_id) {
+          emojiName = emoji.emoji_name
+        }
+      })
+      if (data.count > 0) return `${this.$store.state.port}/static/images/JY/color/${emojiName}.jpg`
+      return `${this.$store.state.port}/static/images/JY/gray/${emojiName}.jpg`
     },
     async handleClickChangeMonth(monthSet) {
       const selectMonth = this.$store.state.selectedMonth + monthSet

--- a/MangoDiary/src/components/StatisticsPage.vue
+++ b/MangoDiary/src/components/StatisticsPage.vue
@@ -64,12 +64,7 @@ export default {
       this.$router.push(this.$store.state.calendar)
     },
     getEmojiPath(data) {
-      let emojiName = ''
-      this.$store.state.emojis.forEach(emoji => {
-        if(emoji.emoji_id == data.emoji_id) {
-          emojiName = emoji.emoji_name
-        }
-      })
+      const emojiName = (this.$store.state.emojis.find(emoji => emoji.emoji_id == data.emoji_id)?.emoji_name) ?? ''
       if (data.count > 0) return `${this.$store.state.port}/static/images/JY/color/${emojiName}.jpg`
       return `${this.$store.state.port}/static/images/JY/gray/${emojiName}.jpg`
     },

--- a/MangoDiary/src/components/StatisticsPage.vue
+++ b/MangoDiary/src/components/StatisticsPage.vue
@@ -78,11 +78,13 @@ export default {
       } else if ((selectMonth) > 12) {
         this.$store.commit('increaseSelectedYear')
       }
+      await this.$store.dispatch('getAllPosts')
       this.$store.commit('updateStatistic')
     },
   },
-  mounted() {
+  async mounted() {
     this.$store.commit('getToday')
+    await this.$store.dispatch('getAllPosts')
     this.$store.commit('updateStatistic')
   },
 }

--- a/MangoDiary/src/components/StatisticsPage.vue
+++ b/MangoDiary/src/components/StatisticsPage.vue
@@ -70,7 +70,7 @@ export default {
     getMostSelectedEmojiPath() {
       return `/images/colored/${this.$store.state.statisticsData[0].emoji}.jpg`
     },
-    handleClickChangeMonth(monthSet) {
+    async handleClickChangeMonth(monthSet) {
       const selectMonth = this.$store.state.selectedMonth + monthSet
       this.$store.commit('setSelectedMonth', selectMonth)
       if ((selectMonth) < 1) {

--- a/MangoDiary/src/components/WritePage.vue
+++ b/MangoDiary/src/components/WritePage.vue
@@ -58,6 +58,7 @@ export default {
       diaryId: 0,
       selectedEmoji: null,
       selectedEmojiId: '',
+      data: [],
     };
   },
   methods: {
@@ -77,6 +78,16 @@ export default {
       }
       const response = await axios.post(`${this.$store.state.port}/post/create`, newForm)
       this.diaryId = response.data.post_id
+    },
+    async getPost(id) {
+      const response = await axios.get(`${this.$store.state.port}/post/search/${id}`)
+      this.data = response.data
+      this.diaryContent = this.data.post_content
+      this.selectedImage = `${this.$store.state.port}${this.data.post_upload_image}`
+      this.selectedEmojiId = this.data.post_emoji_id
+      for (let i = 0; i < this.$store.state.emojis.length; i++) {
+        if (this.$store.state.emojis[i].emoji_id == this.selectedEmojiId) this.selectedEmoji = this.$store.state.emojis[i].emoji_name
+      }
     },
     handleClickMoveCalendar() {
       this.$router.push(this.$store.state.calendar)
@@ -133,11 +144,7 @@ export default {
     this.checkDate()
     this.getDiaryId()
     this.selectedDay = this.$route.params.selectedDay
-    if (this.diaryId != -1) {
-        this.diaryContent = this.$store.state.diary[this.diaryId]?.post_content
-        this.selectedImage = this.$store.state.diary[this.diaryId]?.post_upload_image
-        this.selectedEmoji = this.$store.state.diary[this.diaryId]?.post_emoji
-    }
+    if (this.diaryId != -1) this.getPost(this.diaryId)
   },
 };
 </script>

--- a/MangoDiary/src/components/WritePage.vue
+++ b/MangoDiary/src/components/WritePage.vue
@@ -104,12 +104,7 @@ export default {
       this.$router.push(this.$store.state.calendar)
     },
     getEmojiName(emojiId) {
-      let emojiName = ''
-      this.$store.state.emojis.forEach(emoji => {
-        if(emoji.emoji_id == emojiId) {
-          emojiName = emoji.emoji_name
-        }
-      })
+      const emojiName = (this.$store.state.emojis.find(emoji => emoji.emoji_id == emojiId)?.emoji_name) ?? ''
       return emojiName
     },
     getEmojiImagePath(emojiId) {

--- a/MangoDiary/src/components/WritePage.vue
+++ b/MangoDiary/src/components/WritePage.vue
@@ -10,7 +10,7 @@
         <h3 class="emotion">Emotion</h3>
         <div class="emoji-box">
           <div v-for="(emoji, index) in this.$store.state.statisticsData" :key="index">
-            <img :src="getEmojiImagePath(emoji.emoji)" @click="selectEmoji(emoji.emoji)" class="mood-list">
+            <img :src="getEmojiImagePath(emoji.emoji_id)" @click="selectEmoji(emoji.emoji_id)" class="mood-list">
             <div class="emoji-name">{{ emoji.name }}</div>
           </div>
         </div>
@@ -56,6 +56,7 @@ export default {
       selectedDay: null,
       diaryId: 0,
       selectedEmoji: null,
+      selectedEmojiId: '',
     };
   },
   methods: {
@@ -83,11 +84,25 @@ export default {
       });
       this.$router.push(this.$store.state.calendar)
     },
-    getEmojiImagePath(emoji) {
-      return `/images/${this.$store.state.prefix[this.selectedEmoji == emoji ? 0 : 1]}/${emoji}.jpg`
+    getEmojiName(emojiId) {
+      let emojiName = ''
+      this.$store.state.emojis.forEach(emoji => {
+        if(emoji.emoji_id == emojiId) {
+          emojiName = emoji.emoji_name
+        }
+      })
+      return emojiName
     },
-    selectEmoji(emoji) {
-      this.selectedEmoji = emoji
+    getEmojiImagePath(emojiId) {
+      const emojiName = this.getEmojiName(emojiId)
+      return `${this.$store.state.port}/static/images/JY/${this.$store.state.prefix[this.selectedEmoji == emojiName ? 0 : 1]}/${emojiName}.jpg`
+    },
+    selectEmoji(emojiId) {
+      const emojiName = this.getEmojiName(emojiId)
+      this.selectedEmoji = emojiName
+      for (let i = 0; i < this.$store.state.emojis.length; i++) {
+        if (this.$store.state.emojis[i].emoji_color_type == 'color' && this.$store.state.emojis[i].emoji_name == emojiName) this.selectedEmojiId = this.$store.state.emojis[i].emoji_id
+      }
     },
     handleImageUpload(event) {
       const file = event.target.files

--- a/MangoDiary/src/components/WritePage.vue
+++ b/MangoDiary/src/components/WritePage.vue
@@ -47,6 +47,7 @@
 </template>
 
 <script>
+import axios from 'axios'
 export default {
   data() {
     return {

--- a/MangoDiary/src/components/WritePage.vue
+++ b/MangoDiary/src/components/WritePage.vue
@@ -53,6 +53,7 @@ export default {
     return {
       diaryContent: '',
       selectedImage: null,
+      selectedFile: null,
       selectedDay: null,
       diaryId: 0,
       selectedEmoji: null,
@@ -60,6 +61,23 @@ export default {
     };
   },
   methods: {
+    async createPost() {
+      const formData = {
+        post_type: 'JY',
+        post_year: String(this.$store.state.selectedYear),
+        post_month: String(this.$store.state.selectedMonth),
+        post_date: String(this.selectedDay),
+        post_emoji_id: this.selectedEmojiId,
+        post_content: this.diaryContent,
+        post_upload_image: this.selectedFile
+      }
+      const newForm = new FormData()
+      for (const key in formData){
+        newForm.append(key, formData[key])
+      }
+      const response = await axios.post(`${this.$store.state.port}/post/create`, newForm)
+      this.diaryId = response.data.post_id
+    },
     handleClickMoveCalendar() {
       this.$router.push(this.$store.state.calendar)
     },
@@ -68,20 +86,7 @@ export default {
         alert("반드시 감정을 선택해야 합니다")
         return
       }
-      if (this.diaryId == -1) {
-        this.$store.commit('setId')
-        this.diaryId = this.$store.state.diaryId
-        this.$store.commit('setDiary', {
-          id: this.diaryId,
-          day: this.selectedDay
-        })
-      }
-      this.$store.commit('setDiaryEntry', {
-        id: this.diaryId,
-        content: this.diaryContent,
-        image: this.selectedImage,
-        emoji: this.selectedEmoji
-      });
+      this.createPost()
       this.$router.push(this.$store.state.calendar)
     },
     getEmojiName(emojiId) {
@@ -106,6 +111,7 @@ export default {
     },
     handleImageUpload(event) {
       const file = event.target.files
+      this.selectedFile = file[0]
       this.selectedImage = URL.createObjectURL(file[0])
     },
     handleClickMoveStatistics() {

--- a/MangoDiary/src/components/WritePage.vue
+++ b/MangoDiary/src/components/WritePage.vue
@@ -83,7 +83,8 @@ export default {
       const response = await axios.get(`${this.$store.state.port}/post/search/${id}`)
       this.data = response.data
       this.diaryContent = this.data.post_content
-      this.selectedImage = `${this.$store.state.port}${this.data.post_upload_image}`
+      if (this.data.post_upload_image == "no image") this.selectedImage = null
+      else this.selectedImage = `${this.$store.state.port}${this.data.post_upload_image}`
       this.selectedEmojiId = this.data.post_emoji_id
       for (let i = 0; i < this.$store.state.emojis.length; i++) {
         if (this.$store.state.emojis[i].emoji_id == this.selectedEmojiId) this.selectedEmoji = this.$store.state.emojis[i].emoji_name

--- a/MangoDiary/src/components/WritePage.vue
+++ b/MangoDiary/src/components/WritePage.vue
@@ -86,9 +86,11 @@ export default {
       if (this.data.post_upload_image == "no image") this.selectedImage = null
       else this.selectedImage = `${this.$store.state.port}${this.data.post_upload_image}`
       this.selectedEmojiId = this.data.post_emoji_id
-      for (let i = 0; i < this.$store.state.emojis.length; i++) {
-        if (this.$store.state.emojis[i].emoji_id == this.selectedEmojiId) this.selectedEmoji = this.$store.state.emojis[i].emoji_name
-      }
+      this.$store.state.emojis.forEach(emoji => {
+        if (emoji.emoji_id == this.selectedEmojiId) {
+          this.selectedEmoji = emoji.emoji_name
+        }
+      })
     },
     handleClickMoveCalendar() {
       this.$router.push(this.$store.state.calendar)
@@ -117,9 +119,11 @@ export default {
     selectEmoji(emojiId) {
       const emojiName = this.getEmojiName(emojiId)
       this.selectedEmoji = emojiName
-      for (let i = 0; i < this.$store.state.emojis.length; i++) {
-        if (this.$store.state.emojis[i].emoji_color_type == 'color' && this.$store.state.emojis[i].emoji_name == emojiName) this.selectedEmojiId = this.$store.state.emojis[i].emoji_id
-      }
+      this.$store.state.emojis.forEach(emoji => {
+        if (emoji.emoji_color_type == 'color' && emoji.emoji_name == emojiName) {
+          this.selectedEmojiId = emoji.emoji_id
+        }
+      })
     },
     handleImageUpload(event) {
       const file = event.target.files

--- a/MangoDiary/src/data/data.js
+++ b/MangoDiary/src/data/data.js
@@ -1,2 +1,0 @@
-const data = []
-  export default data;

--- a/MangoDiary/src/data/statistic.js
+++ b/MangoDiary/src/data/statistic.js
@@ -2,35 +2,35 @@ const statisticsData = [
     {
         month: '화나는 달',
         name: '화남',
-        emoji_id: '2cc3a655-bdb5-4c24-9f83-c7e531d53b1c',
+        emoji_id: '4c4ca366-7100-4000-ad52-c7db885545de',
         count: 0,
         comment: "어려움과 화남을 뒤로하고, 새로운\n달을 긍정적으로 맞이해봐요"
     },
     {
         month: '우울한 달',
         name: '우울',
-        emoji_id: "c944cb7a-b6da-4b28-9464-b7c3eb2c9e3a",
+        emoji_id: "237eec73-8f76-494e-8a2e-445591daa5ae",
         count: 0,
         comment: "어려움과 우울함을 뒤로하고,\n새로운 달을 긍정적으로 맞이해봐요"
     },
     {
         month: '기쁜 달',
         name: '기쁨',
-        emoji_id: "15b61694-d624-4fe0-92ac-d72c4dbaba1a",
+        emoji_id: "56295f49-267c-454f-b351-e69ef89c40fc",
         count: 0,
         comment: "좋았던 이번 달처럼, 새로운 달을\n긍정적으로 맞이해봐요"
     },
     {
         month: '행복한 달',
         name: '행복',
-        emoji_id: "cd312fb7-257e-41cb-8bc4-54c44395858e",
+        emoji_id: "fbde22e7-e8ef-4cc5-9a0a-c7f30ed468d5",
         count: 0,
         comment: "행복했던 이번 달처럼, 새로운 달을\n긍정적으로 맞이해봐요"
     },
     {
         month: '슬픈 달',
         name: '슬픔',
-        emoji_id: "5b29f9bd-4ab8-42ac-987a-d154578f23b5",
+        emoji_id: "64a27fe2-935d-4c7a-affa-c39c2f498b52",
         count: 0,
         comment: "어려움과 슬픔을 뒤로하고, 새로운\n달을 긍정적으로 맞이해봐요"
     },

--- a/MangoDiary/src/data/statistic.js
+++ b/MangoDiary/src/data/statistic.js
@@ -2,35 +2,35 @@ const statisticsData = [
     {
         month: '화나는 달',
         name: '화남',
-        emoji: 'angry',
+        emoji_id: '2cc3a655-bdb5-4c24-9f83-c7e531d53b1c',
         count: 0,
         comment: "어려움과 화남을 뒤로하고, 새로운\n달을 긍정적으로 맞이해봐요"
     },
     {
         month: '우울한 달',
         name: '우울',
-        emoji: 'depressed',
+        emoji_id: "c944cb7a-b6da-4b28-9464-b7c3eb2c9e3a",
         count: 0,
         comment: "어려움과 우울함을 뒤로하고,\n새로운 달을 긍정적으로 맞이해봐요"
     },
     {
         month: '기쁜 달',
         name: '기쁨',
-        emoji: 'pleased',
+        emoji_id: "15b61694-d624-4fe0-92ac-d72c4dbaba1a",
         count: 0,
         comment: "좋았던 이번 달처럼, 새로운 달을\n긍정적으로 맞이해봐요"
     },
     {
         month: '행복한 달',
         name: '행복',
-        emoji: 'happy',
+        emoji_id: "cd312fb7-257e-41cb-8bc4-54c44395858e",
         count: 0,
         comment: "행복했던 이번 달처럼, 새로운 달을\n긍정적으로 맞이해봐요"
     },
     {
         month: '슬픈 달',
         name: '슬픔',
-        emoji: 'sad',
+        emoji_id: "5b29f9bd-4ab8-42ac-987a-d154578f23b5",
         count: 0,
         comment: "어려움과 슬픔을 뒤로하고, 새로운\n달을 긍정적으로 맞이해봐요"
     },

--- a/MangoDiary/src/store.js
+++ b/MangoDiary/src/store.js
@@ -38,18 +38,18 @@ const store = createStore({
     },
     mutations: {
         getToday(state) {
-            state.date = new Date();
-            state.selectedYear = state.date.getFullYear();
-            state.selectedMonth = state.date.getMonth() + 1;
-            state.currentYear = state.date.getFullYear();
-            state.currentMonth = state.date.getMonth() + 1;
-            state.today = state.date.getDate();
+            state.date = new Date()
+            state.selectedYear = state.date.getFullYear()
+            state.selectedMonth = state.date.getMonth() + 1
+            state.currentYear = state.date.getFullYear()
+            state.currentMonth = state.date.getMonth() + 1
+            state.today = state.date.getDate()
         },
         setSelectedYear(state, year) {
-            state.selectedYear = year;
+            state.selectedYear = year
         },
         setSelectedMonth(state, month) {
-            state.selectedMonth = month;
+            state.selectedMonth = month
         },
         setId(state) {
             state.diaryId++

--- a/MangoDiary/src/store.js
+++ b/MangoDiary/src/store.js
@@ -10,12 +10,14 @@ const ROUTES = {
 }
 const WEEK_NAMES = ['Sun', 'Mon', 'Tues', 'Wed', 'Thur', 'Fri', 'Sat']
 const MONTH_NAMES = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
-const PREFIX = ['colored', 'grey']
+const PREFIX = ['color', 'gray']
+const PORT = 'http://18.117.80.209:3333'
 
 const store = createStore({
     state() {
         return {
             diary : data,
+            emojis: [],
             statisticsData : statisticsData,
             statistics : ROUTES.statistics,
             calendar : ROUTES.calendar,
@@ -30,6 +32,7 @@ const store = createStore({
             monthNames: MONTH_NAMES,
             prefix: PREFIX,
             diaryId: 0,
+            port: PORT,
             posts: [],
         }
     },
@@ -75,6 +78,9 @@ const store = createStore({
                 post_upload_image: null
               }
         },
+        setEmojis(state, emojis) {
+          state.emojis = emojis
+        },
         setAllPost(state, posts) { 
           state.posts = posts
         },
@@ -95,6 +101,15 @@ const store = createStore({
         }
     },
     actions: {
+        async getAllEmojis(context){ 
+            try {
+                const response = await axios.get(`${context.state.port}/emoji/all`)
+                const allEmojis = response.data.filter(emoji => emoji.emoji_type == 'JY')
+                context.commit('setEmojis', allEmojis)
+            } catch (error) {
+            console.log('[Error] getAllEmojis Failed,', error)
+            }
+        },
         async getAllPosts(context){
             try {
                 const allPostUrl = `${context.state.port}/post/all`

--- a/MangoDiary/src/store.js
+++ b/MangoDiary/src/store.js
@@ -1,6 +1,7 @@
 import { createStore } from 'vuex';
 import data from './data/data.js'
 import statisticsData from './data/statistic.js'
+import axios from 'axios'
 
 const ROUTES = {
     statistics: '/statistics',

--- a/MangoDiary/src/store.js
+++ b/MangoDiary/src/store.js
@@ -88,17 +88,20 @@ const store = createStore({
             state.statisticsData.forEach((item) => {
                 item.count = 0
             })
-            state.diary.forEach(post => {
-                if (post.post_month == state.selectedMonth && post.post_year == state.selectedYear) {
+            const daysInMonth = new Date(state.selectedYear, state.selectedMonth, 0).getDate()
+            for (let i = 0; i < daysInMonth; i++) {
+                const datedPost = state.posts.filter(post => post.post_date == `${i}`)
+                if (datedPost.length > 0){
                     state.statisticsData.forEach(statistic => {
-                        if (post.post_emoji == statistic.emoji) {
-                            statistic.count++;
+                        if (datedPost[datedPost.length - 1].post_emoji_id == statistic.emoji_id) {
+                            statistic.count++
                         }
                     })
                 }
+            }
             })
             state.statisticsData.sort((a, b) => b.count - a.count)
-        }
+        },
     },
     actions: {
         async getAllEmojis(context){ 

--- a/MangoDiary/src/store.js
+++ b/MangoDiary/src/store.js
@@ -1,5 +1,4 @@
 import { createStore } from 'vuex';
-import data from './data/data.js'
 import statisticsData from './data/statistic.js'
 import axios from 'axios'
 
@@ -16,7 +15,6 @@ const PORT = 'http://18.117.80.209:3333'
 const store = createStore({
     state() {
         return {
-            diary : data,
             emojis: [],
             statisticsData : statisticsData,
             statistics : ROUTES.statistics,

--- a/MangoDiary/src/store.js
+++ b/MangoDiary/src/store.js
@@ -30,6 +30,7 @@ const store = createStore({
             monthNames: MONTH_NAMES,
             prefix: PREFIX,
             diaryId: 0,
+            posts: [],
         }
     },
     mutations: {
@@ -74,6 +75,9 @@ const store = createStore({
                 post_upload_image: null
               }
         },
+        setAllPost(state, posts) { 
+          state.posts = posts
+        },
         updateStatistic(state) {
             state.statisticsData.forEach((item) => {
                 item.count = 0
@@ -91,6 +95,32 @@ const store = createStore({
         }
     },
     actions: {
+        async getAllPosts(context){
+            try {
+                const allPostUrl = `${context.state.port}/post/all`
+                const requestData = {
+                    post_month: String(context.state.selectedMonth),
+                    post_year: String(context.state.selectedYear),
+                    post_type: 'JY',
+                }
+                const response = await axios.post(allPostUrl, requestData)
+                const beforePosts = response.data
+
+                const getEmojiUrls = beforePosts.map((post) => {
+                    const currentEmoji = post.post_emoji_id
+                    let emojiUrl = ''
+                    context.state.emojis.forEach((emoji) => {
+                        if (emoji.emoji_id == currentEmoji) {
+                        emojiUrl = `${context.state.port}${emoji.emoji_image}`
+                        }
+                    })
+                    return {...post, 'post_emoji_url': emojiUrl}
+                })
+                context.commit('setAllPost', getEmojiUrls)
+            } catch (error) {
+                console.log('[Error] getAllPosts Failed,', error)
+            }
+        }
     }
 })
 

--- a/MangoDiary/src/store.js
+++ b/MangoDiary/src/store.js
@@ -97,7 +97,6 @@ const store = createStore({
                     })
                 }
             }
-            })
             state.statisticsData.sort((a, b) => b.count - a.count)
         },
     },

--- a/MangoDiary/vite.config.js
+++ b/MangoDiary/vite.config.js
@@ -8,6 +8,9 @@ export default defineConfig({
   plugins: [
     vue(),
   ],
+  server: {
+    port: 3000,
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))


### PR DESCRIPTION
## Docs

- [figma design template](https://www.figma.com/file/0ByGSnJpm6DdAwqOrPSSeR/Mango-Diary?type=design&node-id=42-7&mode=design&t=0l1d4P49WtZECEZu-0)

## Changes

- before : api를 사용하지 않음
- after : api를 이용해서 데이터를 불러오고 저장
- images
![localhost_5173_(iphone 14) (3)](https://github.com/DEV-TINO/Mango-Diary-JY/assets/146654623/aaf9f1b1-c1a0-4e95-aae0-8d209afdee65)
![localhost_5173_(iphone 14)](https://github.com/DEV-TINO/Mango-Diary-JY/assets/146654623/d500bcce-a627-4a34-8dd4-1f1352f9ee18)
![localhost_5173_(iphone 14) (1)](https://github.com/DEV-TINO/Mango-Diary-JY/assets/146654623/9073bb56-2fe6-4896-85ec-d86f0d9bd797)
![localhost_5173_(iphone 14) (2)](https://github.com/DEV-TINO/Mango-Diary-JY/assets/146654623/7bcc0202-f793-42dc-a6c3-9dabdc927cb2)

## Review Points
- 캘린더에 이모지가 잘 표시 되는지
- 캘린더의 날짜를 누르면 일기 작성 페이지로 잘 넘어가 지는지
- 이모지가 이미 존재하는 날짜를 누르면 저장되어 있던 일기가 불러와지는지
- 일기 작성 페이지에서 이모지를 누르면 gray scale에서 color scale로 변하며 선택 되는지
- submit버튼을 통해서 일기가 저장되는지
- 통계 페이지에 각 이모지 별 통계가 잘 보이는지
#### Problem
- 일기를 수정했을 때 배열의 데이터가 수정되는 것이 아닌 새로운 일기 데이터가 작성이 되다보니 모든 포스트를 불러와서 이모지의 개수 통계값을 내면 가장 최신의 일기가 아닌 수정 되어서 쓰이지 않는 일기의 이모지의 개수까지 카운트 해서 통계페이지가 제대로 동작하지 않는다
#### Solution
- 이모지 개수를 수집하기 전에 포스트를 불러온 뒤 날짜별로 배열을 만들어 나누어 저장한다. 각 배열에서 가장 최신의 데이터만 골라서 이모지의 개수를 카운트 하면 제대로 동작한다
## Test Checklist

- [x] 캘린더에 이모지가 잘 표시 되는지
- [x] 캘린더의 날짜를 누르면 일기 작성 페이지로 잘 넘어가 지는지
- [x] 이모지가 이미 존재하는 날짜를 누르면 저장되어 있던 일기가 불러와지는지
- [x] 일기 작성 페이지에서 이모지를 누르면 gray scale에서 color scale로 변하며 선택 되는지
- [x] submit버튼을 통해서 일기가 저장되는지
- [x] 통계 페이지에 각 이모지 별 통계가 잘 보이는지
